### PR TITLE
WC now includes packages

### DIFF
--- a/finder.php
+++ b/finder.php
@@ -1,6 +1,9 @@
 <?php
 
 return \StubsGenerator\Finder::create()
-    ->in(['wp-content/plugins/woocommerce/includes'])
-    ->append(['wp-content/plugins/woocommerce/woocommerce.php'])
+    ->in([
+        'wp-content/plugins/woocommerce/woocommerce.php',
+        'wp-content/plugins/woocommerce/includes',
+        'wp-content/plugins/woocommerce/packages/*/src',
+    ])
     ->sortByName();

--- a/finder.php
+++ b/finder.php
@@ -2,8 +2,8 @@
 
 return \StubsGenerator\Finder::create()
     ->in([
-        'wp-content/plugins/woocommerce/woocommerce.php',
         'wp-content/plugins/woocommerce/includes',
         'wp-content/plugins/woocommerce/packages/*/src',
     ])
+    ->append(\StubsGenerator\Finder::create()->files()->depth('< 1')->name('woocommerce.php')->in(['woocommerce']))
     ->sortByName();

--- a/finder.php
+++ b/finder.php
@@ -3,7 +3,7 @@
 return \StubsGenerator\Finder::create()
     ->in([
         'wp-content/plugins/woocommerce/includes',
-        'wp-content/plugins/woocommerce/packages/*/src',
+        // 'wp-content/plugins/woocommerce/packages/*/src', TODO Put packages into separate stubs files.
     ])
     ->append(\StubsGenerator\Finder::create()->files()->depth('< 1')->name('woocommerce.php')->in(['woocommerce']))
     ->sortByName();


### PR DESCRIPTION
somehow they appear in `/packages`
https://github.com/woocommerce/woocommerce/blob/master/composer.json#L13-L14

I'm not able to decide: Do we really need packages stubs?
Maybe no one will write code that uses code from woocommerce-blocks or woocommerce-rest-api.

What do you think?

btw. please see https://github.com/php-stubs/woocommerce-stubs